### PR TITLE
🔨 Introduce FASTFLOAT_INSTALL to make install optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,13 +22,18 @@ if (NOT CMAKE_BUILD_TYPE)
   endif()
 endif()
 
+option(FASTFLOAT_INSTALL "Enable install" ON)
+
+if(FASTFLOAT_INSTALL)
+  include(GNUInstallDirs)
+endif()
 
 add_library(fast_float INTERFACE)
 target_include_directories(
   fast_float
   INTERFACE
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 if(FASTFLOAT_SANITIZE)
   target_compile_options(fast_float INTERFACE -fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=all)
@@ -42,29 +47,30 @@ if(MSVC_VERSION GREATER 1910)
 endif()
 
 
-include(GNUInstallDirs)
-include(CMakePackageConfigHelpers)
+if(FASTFLOAT_INSTALL)
+  include(CMakePackageConfigHelpers)
 
-set(FASTFLOAT_VERSION_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/module/FastFloatConfigVersion.cmake")
-set(FASTFLOAT_PROJECT_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/module/FastFloatConfig.cmake")
-set(FASTFLOAT_CONFIG_INSTALL_DIR "${CMAKE_INSTALL_DATAROOTDIR}/cmake/FastFloat")
+  set(FASTFLOAT_VERSION_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/module/FastFloatConfigVersion.cmake")
+  set(FASTFLOAT_PROJECT_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/module/FastFloatConfig.cmake")
+  set(FASTFLOAT_CONFIG_INSTALL_DIR "${CMAKE_INSTALL_DATAROOTDIR}/cmake/FastFloat")
 
-if(${CMAKE_VERSION} VERSION_LESS "3.14")
-  write_basic_package_version_file("${FASTFLOAT_VERSION_CONFIG}" VERSION ${PROJECT_VERSION} COMPATIBILITY SameMajorVersion)
-else()
-  write_basic_package_version_file("${FASTFLOAT_VERSION_CONFIG}" VERSION ${PROJECT_VERSION} COMPATIBILITY SameMajorVersion ARCH_INDEPENDENT)
+  if(${CMAKE_VERSION} VERSION_LESS "3.14")
+    write_basic_package_version_file("${FASTFLOAT_VERSION_CONFIG}" VERSION ${PROJECT_VERSION} COMPATIBILITY SameMajorVersion)
+  else()
+    write_basic_package_version_file("${FASTFLOAT_VERSION_CONFIG}" VERSION ${PROJECT_VERSION} COMPATIBILITY SameMajorVersion ARCH_INDEPENDENT)
+  endif()
+  configure_package_config_file("cmake/config.cmake.in"
+                                "${FASTFLOAT_PROJECT_CONFIG}"
+                                INSTALL_DESTINATION "${FASTFLOAT_CONFIG_INSTALL_DIR}")
+
+  install(DIRECTORY "${PROJECT_SOURCE_DIR}/include/fast_float" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+  install(FILES "${FASTFLOAT_PROJECT_CONFIG}" "${FASTFLOAT_VERSION_CONFIG}" DESTINATION "${FASTFLOAT_CONFIG_INSTALL_DIR}")
+  install(EXPORT ${PROJECT_NAME}-targets NAMESPACE FastFloat:: DESTINATION "${FASTFLOAT_CONFIG_INSTALL_DIR}")
+
+  install(TARGETS fast_float
+          EXPORT ${PROJECT_NAME}-targets
+          RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  )
 endif()
-configure_package_config_file("cmake/config.cmake.in"
-                              "${FASTFLOAT_PROJECT_CONFIG}"
-                              INSTALL_DESTINATION "${FASTFLOAT_CONFIG_INSTALL_DIR}")
-
-install(DIRECTORY "${PROJECT_SOURCE_DIR}/include/fast_float" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
-install(FILES "${FASTFLOAT_PROJECT_CONFIG}" "${FASTFLOAT_VERSION_CONFIG}" DESTINATION "${FASTFLOAT_CONFIG_INSTALL_DIR}")
-install(EXPORT ${PROJECT_NAME}-targets NAMESPACE FastFloat:: DESTINATION "${FASTFLOAT_CONFIG_INSTALL_DIR}")
-
-install(TARGETS fast_float 
-        EXPORT ${PROJECT_NAME}-targets
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ if(FASTFLOAT_INSTALL)
 endif()
 
 add_library(fast_float INTERFACE)
+add_library(FastFloat::fast_float ALIAS fast_float)
 target_include_directories(
   fast_float
   INTERFACE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 3.9)
 
 project(fast_float VERSION 3.4.0 LANGUAGES CXX)
 option(FASTFLOAT_TEST "Enable tests" OFF)
-set(CMAKE_CXX_STANDARD 11 CACHE STRING "C++ standard to be used")
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if(FASTFLOAT_TEST)
   enable_testing()
   add_subdirectory(tests)
@@ -35,6 +33,7 @@ target_include_directories(
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
+target_compile_features(fast_float INTERFACE cxx_std_11)
 if(FASTFLOAT_SANITIZE)
   target_compile_options(fast_float INTERFACE -fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=all)
   target_link_libraries(fast_float INTERFACE -fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=all)


### PR DESCRIPTION
When using fast_float as a PRIVATE dependency, it is not required to install it. This flag give user using fastfloat with add_subdirectory the opportunity to disable install target Default behavior is conserved since FASTFLOAT_INSTALL is ON